### PR TITLE
SimplifiedMasternodeListManager: Handle other exceptions when loading bootstrap

### DIFF
--- a/core/src/main/java/org/bitcoinj/evolution/SimplifiedMasternodeListManager.java
+++ b/core/src/main/java/org/bitcoinj/evolution/SimplifiedMasternodeListManager.java
@@ -892,6 +892,10 @@ public class SimplifiedMasternodeListManager extends AbstractManager {
                     log.info("failed loading mnlist bootstrap file" + x.getMessage());
                 } catch (IOException x) {
                     log.info("failed loading mnlist bootstrap file" + x.getMessage());
+                } catch (IllegalStateException x) {
+                    log.info("failed loading mnlist bootstrap file" + x.getMessage());
+                } catch (NullPointerException x) {
+                    log.info("failed loading mnlist bootstrap file" + x.getMessage());
                 } finally {
                     isLoadingBootStrap = false;
                     try {


### PR DESCRIPTION
Some exceptions were found to occur on some android versions that
resulted in crashes.  This will catch those.

This would also need to be `cherry-pick`ed into the release-0.16 branch if needed for 0.16.4