### PR TITLE
Use BLS Lazy Public keys on DMN Lists

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/BLSLazyPublicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BLSLazyPublicKey.java
@@ -54,7 +54,6 @@ public class BLSLazyPublicKey extends ChildMessage {
         this.isPublicKeyInitialized = true;
     }
 
-
     public BLSLazyPublicKey(NetworkParameters params, byte [] payload, int offset) {
         super(params, payload, offset);
     }
@@ -94,5 +93,9 @@ public class BLSLazyPublicKey extends ChildMessage {
     @Override
     public String toString() {
         return isPublicKeyInitialized ? publicKey.toString() : (buffer == null ? invalidSignature.toString() : Utils.HEX.encode(buffer));
+    }
+
+    public boolean isPublicKeyInitialized() {
+        return isPublicKeyInitialized;
     }
 }

--- a/core/src/main/java/org/bitcoinj/crypto/BLSLazyPublicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BLSLazyPublicKey.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Dash Core Group.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.crypto;
+
+import org.bitcoinj.core.ChildMessage;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.ProtocolException;
+import org.bitcoinj.core.Utils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * BLSPublicKey uses 152 bytes of native memory + java overhead,
+ * while a serialized public key is 48 bytes
+ *
+ * BLSLazyPublicKey will keep the public key stored as the 48 bytes until it needs to be used
+ * to perform an operation that requires BLSPublicKey
+ *
+ * Unlike BLSLazySignature, this class is Immutable
+ */
+
+public class BLSLazyPublicKey extends ChildMessage {
+
+    byte [] buffer;
+    BLSPublicKey publicKey;
+    boolean isPublicKeyInitialized;
+
+    public BLSLazyPublicKey(NetworkParameters params) {
+        super(params);
+    }
+
+    public BLSLazyPublicKey(BLSLazyPublicKey publicKey) {
+        super(publicKey.params);
+        this.buffer = publicKey.buffer;
+        this.publicKey = publicKey.publicKey;
+        this.isPublicKeyInitialized = publicKey.isPublicKeyInitialized;
+    }
+
+    public BLSLazyPublicKey(NetworkParameters params, byte [] payload, int offset) {
+        super(params, payload, offset);
+    }
+
+    @Override
+    protected void parse() throws ProtocolException {
+        buffer = readBytes(BLSPublicKey.BLS_CURVE_PUBKEY_SIZE);
+        isPublicKeyInitialized = false;
+        length = cursor - offset;
+    }
+
+    @Override
+    protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
+        if (!isPublicKeyInitialized && buffer == null) {
+            throw new IOException("public key and buffer are not initialized");
+        }
+        if (buffer == null) {
+            stream.write(publicKey.getBuffer(BLSPublicKey.BLS_CURVE_PUBKEY_SIZE));
+        } else {
+            stream.write(buffer);
+        }
+    }
+
+    public static BLSPublicKey invalidSignature = new BLSPublicKey();
+
+    public BLSPublicKey getPublicKey() {
+        if(buffer == null && !isPublicKeyInitialized)
+            return invalidSignature;
+        if(!isPublicKeyInitialized) {
+            publicKey = new BLSPublicKey(params, buffer, 0);
+            buffer = null;  //save memory
+            isPublicKeyInitialized = true;
+        }
+        return publicKey;
+    }
+
+    @Override
+    public String toString() {
+        return isPublicKeyInitialized ? publicKey.toString() : (buffer == null ? invalidSignature.toString() : Utils.HEX.encode(buffer));
+    }
+}

--- a/core/src/main/java/org/bitcoinj/crypto/BLSLazyPublicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BLSLazyPublicKey.java
@@ -15,10 +15,7 @@
  */
 package org.bitcoinj.crypto;
 
-import org.bitcoinj.core.ChildMessage;
-import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.core.ProtocolException;
-import org.bitcoinj.core.Utils;
+import org.bitcoinj.core.*;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -49,6 +46,14 @@ public class BLSLazyPublicKey extends ChildMessage {
         this.publicKey = publicKey.publicKey;
         this.isPublicKeyInitialized = publicKey.isPublicKeyInitialized;
     }
+
+    public BLSLazyPublicKey(BLSPublicKey publicKey) {
+        super(Context.get().getParams());
+        this.buffer = null;
+        this.publicKey = publicKey;
+        this.isPublicKeyInitialized = true;
+    }
+
 
     public BLSLazyPublicKey(NetworkParameters params, byte [] payload, int offset) {
         super(params, payload, offset);

--- a/core/src/main/java/org/bitcoinj/evolution/SimplifiedMasternodeListEntry.java
+++ b/core/src/main/java/org/bitcoinj/evolution/SimplifiedMasternodeListEntry.java
@@ -1,6 +1,7 @@
 package org.bitcoinj.evolution;
 
 import org.bitcoinj.core.*;
+import org.bitcoinj.crypto.BLSLazyPublicKey;
 import org.bitcoinj.crypto.BLSPublicKey;
 
 import java.io.IOException;
@@ -12,7 +13,7 @@ public class SimplifiedMasternodeListEntry extends Masternode {
     Sha256Hash confirmedHash;
     MasternodeAddress service;
     KeyId keyIdOperator;
-    BLSPublicKey pubKeyOperator;
+    BLSLazyPublicKey pubKeyOperator;
     KeyId keyIdVoting;
     boolean isValid;
     static int MESSAGE_SIZE = 151;
@@ -36,7 +37,7 @@ public class SimplifiedMasternodeListEntry extends Masternode {
         service = other.service.duplicate();
         keyIdOperator = other.keyIdOperator.duplicate();
         keyIdVoting = other.keyIdVoting.duplicate();
-        pubKeyOperator = new BLSPublicKey(other.pubKeyOperator);
+        pubKeyOperator = new BLSLazyPublicKey(other.pubKeyOperator);
         updateConfirmedHashWithProRegTxHash();
         length = params.isSupportingEvolution() ? MESSAGE_SIZE : MESSAGE_SIZE_OLD;
     }
@@ -52,7 +53,7 @@ public class SimplifiedMasternodeListEntry extends Masternode {
             keyIdOperator = new KeyId(params, payload, cursor);
             cursor += keyIdOperator.getMessageSize();
         } else {
-            pubKeyOperator = new BLSPublicKey(params, payload, cursor);
+            pubKeyOperator = new BLSLazyPublicKey(params, payload, cursor);
             cursor += pubKeyOperator.getMessageSize();
         }
         keyIdVoting = new KeyId(params, payload, cursor);
@@ -120,7 +121,7 @@ public class SimplifiedMasternodeListEntry extends Masternode {
     }
 
     public BLSPublicKey getPubKeyOperator() {
-        return pubKeyOperator;
+        return pubKeyOperator.getPublicKey();
     }
 
     public KeyId getKeyIdVoting() {

--- a/core/src/test/java/org/bitcoinj/crypto/BLSLazyPublicKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/BLSLazyPublicKeyTest.java
@@ -1,0 +1,61 @@
+package org.bitcoinj.crypto;
+
+import org.bitcoinj.core.Context;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.params.MainNetParams;
+import org.dashj.bls.BLS;
+import org.dashj.bls.PrivateKey;
+import org.dashj.bls.PublicKey;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.util.Random;
+
+import static com.google.common.base.Preconditions.checkState;
+import static org.junit.Assert.assertEquals;
+
+public class BLSLazyPublicKeyTest {
+
+    private static NetworkParameters PARAMS = MainNetParams.get();
+
+    static {
+        Context context = new Context(PARAMS);
+        BLS.Init();
+    }
+
+    private byte [] getRandomSeed(int size) {
+        Random rand = new Random();
+        BigInteger result = new BigInteger((size) *8 - 1, rand); // (2^4-1) = 15 is the maximum value
+        byte [] bytes = new byte [32];
+        System.arraycopy(result.toByteArray(), 0, bytes, 0, result.toByteArray().length);
+        return bytes;
+    }
+
+    @Test
+    public void testLazyPublicKey() {
+        // Generate a random public key
+        byte [] seed = getRandomSeed(32);
+        PrivateKey sk = PrivateKey.FromSeed(seed, seed.length);
+        PublicKey pk = sk.GetPublicKey();
+
+        byte [] publicKeyBytes = pk.Serialize();
+        BLSPublicKey publicKey = new BLSPublicKey(PARAMS, publicKeyBytes, 0);
+
+        // create a lazy public key from the bytes only
+        BLSLazyPublicKey lazyPublicKeyFromBytes = new BLSLazyPublicKey(PARAMS, publicKeyBytes, 0);
+        checkState(!lazyPublicKeyFromBytes.isPublicKeyInitialized()); // the BLS object should not be initialized
+
+        // create a lazy public key from a BLS public key object
+        BLSLazyPublicKey lazyPublicKeyFromObject = new BLSLazyPublicKey(publicKey);
+        checkState(lazyPublicKeyFromObject.isPublicKeyInitialized()); // the BLS object should be initialized
+
+        //ensure that the serialized string forms match
+        assertEquals(lazyPublicKeyFromBytes.toString(), lazyPublicKeyFromObject.toString());
+
+        // initialize the lazy public key that was created from bytes
+        BLSPublicKey initializedPublicKey = lazyPublicKeyFromBytes.getPublicKey();
+        checkState(lazyPublicKeyFromBytes.isPublicKeyInitialized()); // the BLS object should be initialized
+        assertEquals(lazyPublicKeyFromBytes.toString(), lazyPublicKeyFromObject.toString());
+
+    }
+}

--- a/core/src/test/java/org/bitcoinj/evolution/SimplifiedMasternodesTest.java
+++ b/core/src/test/java/org/bitcoinj/evolution/SimplifiedMasternodesTest.java
@@ -1,7 +1,10 @@
 package org.bitcoinj.evolution;
 
 import org.bitcoinj.core.*;
+import org.bitcoinj.crypto.BLSLazyPublicKey;
+import org.bitcoinj.crypto.BLSPublicKey;
 import org.bitcoinj.crypto.BLSSecretKey;
+import org.bitcoinj.crypto.BLSSignature;
 import org.bitcoinj.params.MainNetParams;
 import static org.junit.Assert.*;
 
@@ -55,7 +58,7 @@ public class SimplifiedMasternodesTest {
             BLSSecretKey sk = new BLSSecretKey(skBuf);
 
 
-            smle.pubKeyOperator = sk.GetPublicKey();
+            smle.pubKeyOperator = new BLSLazyPublicKey(sk.GetPublicKey());
             smle.keyIdVoting = new KeyId(Utils.reverseBytes(Utils.HEX.decode(String.format("%040x", i))));
             smle.isValid = true;
 


### PR DESCRIPTION
The public keys are only used to verify quorums every 24 blocks.

A public key uses 152 bytes of native memory = about 0.7 MB for 5000 masternodes.

This memory is largely unused.  The idea behind lazy public keys is to store a public key only as the 48 bytes until it needs to be used to verify a quorum.  After that this implementation keeps the public key in memory as a BLSPublicKey (using java and native memory) and allows the 48 bytes to be freed up.

Perhaps a further optimization for reducing memory would be to always convert the 48 bytes to public keys each time the key is required, which is not often in SPV mode.