### PR TITLE
DeterministicKey: Add support for contact pub key (serialize, deserialize)

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/Secp256k1ECDHAgreement.java
+++ b/core/src/main/java/org/bitcoinj/crypto/Secp256k1ECDHAgreement.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Dash Core Group
+ *
+ * Licensed under the MIT license (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://opensource.org/licenses/mit-license.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.crypto;
+
+import org.bitcoinj.core.Sha256Hash;
+import org.bouncycastle.crypto.BasicAgreement;
+import org.bouncycastle.crypto.CipherParameters;
+import org.bouncycastle.crypto.params.ECDomainParameters;
+import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
+import org.bouncycastle.crypto.params.ECPublicKeyParameters;
+import org.bouncycastle.math.ec.ECAlgorithms;
+import org.bouncycastle.math.ec.ECConstants;
+import org.bouncycastle.math.ec.ECPoint;
+
+import java.math.BigInteger;
+
+/**
+ * P1363 7.2.1 ECSVDP-DH
+ *
+ * ECSVDP-DH is Elliptic Curve Secret Value Derivation Primitive,
+ * Diffie-Hellman version. It is based on the work of [DH76], [Mil86],
+ * and [Kob87]. This primitive derives a shared secret value from one
+ * party's private key and another party's public key, where both have
+ * the same set of EC domain parameters. If two parties correctly
+ * execute this primitive, they will produce the same output. This
+ * primitive can be invoked by a scheme to derive a shared secret key;
+ * specifically, it may be used with the schemes ECKAS-DH1 and
+ * DL/ECKAS-DH2. It assumes that the input keys are valid (see also
+ * Section 7.2.2).
+ *
+ * This also follows the derivation in secp256k1_ecdh, which computes
+ * the hash of the version (taken from the last byte of y) and x.
+ */
+public class Secp256k1ECDHAgreement
+        implements BasicAgreement
+{
+    private ECPrivateKeyParameters key;
+
+    public void init(
+            CipherParameters key)
+    {
+        this.key = (ECPrivateKeyParameters)key;
+    }
+
+    public int getFieldSize()
+    {
+        return (key.getParameters().getCurve().getFieldSize() + 7) / 8;
+    }
+
+    public BigInteger calculateAgreement(
+            CipherParameters pubKey)
+    {
+        ECPublicKeyParameters pub = (ECPublicKeyParameters)pubKey;
+        ECDomainParameters params = key.getParameters();
+        if (!params.equals(pub.getParameters()))
+        {
+            throw new IllegalStateException("ECDH public key has wrong domain parameters");
+        }
+
+        BigInteger d = key.getD();
+
+        // Always perform calculations on the exact curve specified by our private key's parameters
+        ECPoint Q = ECAlgorithms.cleanPoint(params.getCurve(), pub.getQ());
+        if (Q.isInfinity())
+        {
+            throw new IllegalStateException("Infinity is not a valid public key for ECDH");
+        }
+
+        BigInteger h = params.getH();
+        if (!h.equals(ECConstants.ONE))
+        {
+            d = params.getHInv().multiply(d).mod(params.getN());
+            Q = ECAlgorithms.referenceMultiply(Q, h);
+        }
+
+        ECPoint P = Q.multiply(d).normalize();
+        if (P.isInfinity())
+        {
+            throw new IllegalStateException("Infinity is not a valid agreement value for ECDH");
+        }
+
+        // this method differs from calculateAgreement in ECDHBasicAgreement which returns
+        // P.getAffineXCoord().toBigInteger().  Since this class follows the secp256k1_ecdh
+        // key derivation method, we will need to compute the hash of the point by
+        // SHA256((y[31]&0x2|0x1) + x) which is the hash of the version and x
+        byte [] x32 = P.getAffineXCoord().getEncoded();
+        byte [] y32 = P.getAffineYCoord().getEncoded();
+        byte [] x32withVersion = new byte [x32.length + 1];
+        x32withVersion[0] = (byte)((y32[y32.length - 1] & 0x01) | 0x02);
+        System.arraycopy(x32, 0, x32withVersion, 1, 32);
+        return new BigInteger(Sha256Hash.hash(x32withVersion));
+    }
+}

--- a/core/src/test/java/org/bitcoinj/crypto/KeyCrypterECDHTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/KeyCrypterECDHTest.java
@@ -17,12 +17,24 @@
 
 package org.bitcoinj.crypto;
 
+import org.bitcoinj.core.Base58;
 import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Utils;
+import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.wallet.DeterministicKeyChain;
+import org.bitcoinj.wallet.FriendKeyChain;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -36,8 +48,8 @@ public class KeyCrypterECDHTest {
 
     @Before
     public void setup() {
-        aliceKey = ECKey.fromPrivate(Utils.HEX.decode("7337920e97ebfe34ee82137a26ef7bd296a3132f3c6494235e1f17820770aa01"));//fromSeed(aliceSeed);
-        bobKey = ECKey.fromPrivate(Utils.HEX.decode("0086b1dd5edf5e19e17e086dbf296d8d697438fb11ef0dd044e186e634d3c99ff7")); //.fromSeed(bobSeed);
+        aliceKey = ECKey.fromPrivate(Utils.HEX.decode("7337920e97ebfe34ee82137a26ef7bd296a3132f3c6494235e1f17820770aa01"));
+        bobKey = ECKey.fromPrivate(Utils.HEX.decode("0086b1dd5edf5e19e17e086dbf296d8d697438fb11ef0dd044e186e634d3c99ff7"));
     }
 
     @Test
@@ -59,22 +71,6 @@ public class KeyCrypterECDHTest {
     }
 
     @Test
-    public void decryptData() {
-        //Bob is receiving from Alice
-        byte initialisationVector[] = Utils.HEX.decode("59da47647645668bab9f7d039b1c87d1");
-        byte encryptedPrivateKey [] = Utils.HEX.decode("34645d7d9c5b9065fc63483abe8b89294050339b0a299b7a1988a27786a860ceb7c518052ecf1583051e8b8fed2c398d");
-
-        EncryptedData encryptedData = new EncryptedData(initialisationVector, encryptedPrivateKey);
-
-        KeyCrypterECDH bobKeyExchangeCrypter = new KeyCrypterECDH();
-        KeyParameter bobKeyParameter = bobKeyExchangeCrypter.deriveKey(bobKey, aliceKey);
-        byte [] decryptedData = bobKeyExchangeCrypter.decrypt(encryptedData, bobKeyParameter);
-        assertNotNull(decryptedData);
-
-        assertEquals("they should be the same string", new String(decryptedData), secret );
-    }
-
-    @Test
     public void deriveECDHwithPublicKeysTest() {
         ECKey alicePublicKey = ECKey.fromPublicOnly(aliceKey.getPubKey());
         ECKey bobPublicKey = ECKey.fromPublicOnly(bobKey.getPubKey());
@@ -83,11 +79,68 @@ public class KeyCrypterECDHTest {
             KeyCrypterECDH bobKeyExchangeCrypter = new KeyCrypterECDH();
             bobKeyExchangeCrypter.deriveKey(bobPublicKey, alicePublicKey);
             fail();
-        } catch (KeyCrypterException x) {
+        } catch (IllegalArgumentException x) {
             // swallow, this is the correct exception
         } catch (Exception x) {
             fail();
         }
     }
 
+    @Test
+    public void ecdhDecryptionTest() {
+        byte [] alicePrivateKey = Utils.HEX.decode("0000000000000000000000000000000000000000000000000000000000000001");
+        byte [] alicePublicKey = Utils.HEX.decode("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798");
+        ECKey bobKeyPair = ECKey.fromPrivate(Utils.HEX.decode("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140"));
+        byte [] encryptedSecret = Utils.HEX.decode("eac5bcd6eb85074759e0261497428c9b3725d3b9ec4d739a842116277c6ace81549089be0d11a54ee09a99dcf7ac695a8ea56d41bf0b62def90b6f78f8b0aca9");
+        //Alice is sending to Bob
+        KeyCrypterECDH aliceKeyExchangeCrypter = new KeyCrypterECDH();
+
+        KeyParameter aliceKeyParameter = aliceKeyExchangeCrypter.deriveKey(alicePrivateKey, bobKeyPair.getPubKey());
+
+        assertEquals("fbd27dbb9e7f471bf3de3704a35e884e37d35c676dc2cc8c3cc574c3962376d2", Utils.HEX.encode(aliceKeyParameter.getKey()));
+        EncryptedData encryptedAliceData = aliceKeyExchangeCrypter.encrypt(secret.getBytes(),
+                Arrays.copyOfRange(encryptedSecret, 0, 16), aliceKeyParameter);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(encryptedAliceData.encryptedBytes.length + encryptedAliceData.initialisationVector.length);
+
+        assertArrayEquals(Arrays.copyOfRange(encryptedSecret, 0, 16), encryptedAliceData.initialisationVector);
+        try {
+            baos.write(encryptedAliceData.initialisationVector);
+            baos.write(encryptedAliceData.encryptedBytes);
+        } catch (IOException x) {
+            fail();
+        }
+        assertArrayEquals("they should be the same data", encryptedSecret, baos.toByteArray());
+
+        //Bob is receiving from Alice
+
+        KeyCrypterECDH bobKeyExchangeCrypter = new KeyCrypterECDH();
+        KeyParameter bobKeyParameter = bobKeyExchangeCrypter.deriveKey(bobKeyPair.getPrivKeyBytes(), alicePublicKey);
+
+        EncryptedData encryptedData = new EncryptedData(Arrays.copyOfRange(encryptedSecret, 0, 16),
+                Arrays.copyOfRange(encryptedSecret, 16, encryptedSecret.length));
+
+        byte[] encryptedBobData = bobKeyExchangeCrypter.decrypt(encryptedData, bobKeyParameter);
+
+        String decryptedSecret = new String(encryptedBobData);
+
+        assertEquals("they should be the same string", secret, decryptedSecret);
+    }
+
+    /* this test uses data from this site, which explained the difference in ECDH implementations
+      https://crypto.stackexchange.com/questions/57695/varying-ecdh-key-output-on-different-ecc-implementations-on-the-secp256k1-curve
+     */
+    @Test
+    public void ecdhTest() {
+        String privkey1 = "82fc9947e878fc7ed01c6c310688603f0a41c8e8704e5b990e8388343b0fd465";
+        String privkey2 = "5f706787ac72c1080275c1f398640fb07e9da0b124ae9734b28b8d0f01eda586";
+
+        ECKey aliceKeyPair = ECKey.fromPrivate(Utils.HEX.decode(privkey1), true);
+        ECKey bobKeyPair = ECKey.fromPrivate(Utils.HEX.decode(privkey2), true);
+
+        KeyCrypterECDH keyExchangeCrypter = new KeyCrypterECDH();
+        KeyParameter keyParameter = keyExchangeCrypter.deriveKey(aliceKeyPair, bobKeyPair);
+
+        assertEquals("5935d0476af9df2998efb60383adf2ff23bc928322cfbb738fca88e49d557d7e", Utils.HEX.encode(keyParameter.getKey()));
+    }
 }

--- a/core/src/test/java/org/bitcoinj/wallet/FriendKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/FriendKeyChainTest.java
@@ -21,6 +21,7 @@ import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.ExtendedChildNumber;
+import org.bitcoinj.crypto.HDKeyDerivation;
 import org.bitcoinj.evolution.EvolutionContact;
 import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.utils.BriefLogFormatter;
@@ -197,8 +198,33 @@ public class FriendKeyChainTest {
         assertEquals(privateChainWatchingKey, publicWatchingKeyFromB58);
 
         assertArrayEquals(privateKey.getPubKey(), publicKeyFromB58.getPubKey());
-        //assertArrayEquals(privateKey.getPubKey(), publicKey.getPubKey());
         assertArrayEquals(privateKey.getPubKey(), publicKeyFromB58.getPubKey());
 
+    }
+
+    @Test
+    public void contactPubTest() {
+        final NetworkParameters PARAMS = UnitTestParams.get();
+        Sha256Hash userAhash = Sha256Hash.wrap("a11ce14f698b32e9bb306dba7bbbee831263dcf658abeebb39930460ead117e5");
+        Sha256Hash userBhash = Sha256Hash.wrap("b0b052ff075c5ca3c16c3e20e9ac8223834475cc1324ab07889cb24ce6a62793");
+
+        EvolutionContact contact = new EvolutionContact(userAhash, 0, userBhash);
+        String tpub = "tpubDLkp5kSwctd6bsLgG2pfbUpLSyjedfkBjy8HYtuczzPUwMCBkRW2Fe7TcEoVin5cLTr6YApGpy2MdKU7sfgLL7cMXTn16dLPdgKMqGg9tVE";
+
+        EvolutionContact theirContact = new EvolutionContact(contact.getFriendUserId(), contact.getUserAccount(), contact.getEvolutionUserId());
+        DeterministicKeyChain publicChainFromB58 = new FriendKeyChain(PARAMS, tpub, theirContact);
+
+        DeterministicKey contactKey = publicChainFromB58.getWatchingKey();
+        byte [] contactPub = contactKey.serializeContactPub();
+        DeterministicKey contactPubKey = DeterministicKey.deserializeContactPub(PARAMS, contactPub);
+
+        // compare the parts that should match.  xpub and tpub strings will not match
+        // due to different depth and child numbers
+        assertEquals(contactKey.getFingerprint(), contactPubKey.getFingerprint());
+        assertArrayEquals(contactKey.getChainCode(), contactPubKey.getChainCode());
+        assertArrayEquals(contactKey.getPubKey(), contactPubKey.getPubKey());
+        DeterministicKey contactKeyFirstKey = HDKeyDerivation.deriveChildKey(contactKey, new ChildNumber(0, false));
+        DeterministicKey contactPubKeyFirstKey = HDKeyDerivation.deriveChildKey(contactPubKey, new ChildNumber(0, false));
+        assertArrayEquals(contactKeyFirstKey.getPubKey(), contactPubKeyFirstKey.getPubKey());
     }
 }


### PR DESCRIPTION
This PR will add support for the DashPay contactRequest encryptedPublicKey (plaintext) serialization format.  This format modifies the format of BIP32 and leaves out header, depth and child number.

Additionally, this PR aligns the ECDH implemention of DashSync with DashJ.