### PR TITLE
[NMA-1006] Android 6.0 sync issues for 0.17

### DIFF
--- a/core/src/main/java/org/bitcoinj/quorums/InstantSendManager.java
+++ b/core/src/main/java/org/bitcoinj/quorums/InstantSendManager.java
@@ -17,8 +17,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -615,7 +617,17 @@ public class InstantSendManager implements RecoveredSignatureListener {
                     db.writeInstantSendLockMined(islockHash, block.getHeight());
                 }
                 // remove related InstantSend Locks from the invalid list
-                invalidInstantSendLocks.entrySet().removeIf(instantSendLockLongEntry -> instantSendLockLongEntry.getKey().getHash().equals(tx.getTxId()));
+                List<InstantSendLock> keysToRemove = new ArrayList<>();
+
+                for (Map.Entry<InstantSendLock, Long> entry : invalidInstantSendLocks.entrySet()) {
+                    if (entry.getKey().getHash().equals(tx.getTxId())) {
+                        keysToRemove.add(entry.getKey());
+                    }
+                }
+
+                for (InstantSendLock key : keysToRemove) {
+                    invalidInstantSendLocks.remove(key);
+                }
             }
         } finally {
             lock.unlock();
@@ -663,7 +675,17 @@ public class InstantSendManager implements RecoveredSignatureListener {
             }
 
             // Keep invalid ISLocks for 1 hour
-            invalidInstantSendLocks.entrySet().removeIf(instantSendLockLongEntry -> instantSendLockLongEntry.getValue() < Utils.currentTimeSeconds() - context.getParams().getInstantSendKeepLock());
+            List<InstantSendLock> keysToRemove = new ArrayList<>();
+
+            for (Map.Entry<InstantSendLock, Long> entry : invalidInstantSendLocks.entrySet()) {
+                if (entry.getValue() < Utils.currentTimeSeconds() - context.getParams().getInstantSendKeepLock()) {
+                    keysToRemove.add(entry.getKey());
+                }
+            }
+
+            for (InstantSendLock key : keysToRemove) {
+                invalidInstantSendLocks.remove(key);
+            }
 
         } finally {
             lock.unlock();


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixing Android <= 6.0 issues that arise because of lambdas.

## What was done?
Instead of using `removeIf` I'm keeping keys that need to be deleted in a separate list and removing them in another loop.

## How Has This Been Tested?
Tested locally on Android API 22 emulator. Currently in QA.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone