### PR TITLE
fix: prevent crash if lazy BLS signature is not initialized

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/BLSLazySignature.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BLSLazySignature.java
@@ -5,6 +5,8 @@ import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.ProtocolException;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.utils.Threading;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -12,6 +14,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public class BLSLazySignature extends ChildMessage {
     ReentrantLock lock = Threading.lock("BLSLazySignature");
+    Logger log = LoggerFactory.getLogger(BLSLazySignature.class);
 
     byte [] buffer;
     BLSSignature signature;
@@ -46,7 +49,8 @@ public class BLSLazySignature extends ChildMessage {
         lock.lock();
         try {
             if (!isSingatureInitialized && buffer == null) {
-                throw new IOException("singature and buffer are not initialized");
+                log.warn("signature and buffer are not initialized");
+                buffer = invalidSignature.getBuffer();
             }
             if (buffer == null) {
                 buffer = signature.getBuffer(BLSSignature.BLS_CURVE_SIG_SIZE);


### PR DESCRIPTION
Signed-off-by: HashEngineering <hashengineeringsolutions@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone