### PR TITLE
feat: add EC and BLS key support to KeyCrypterAESCBC

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypterAESCBC.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypterAESCBC.java
@@ -119,7 +119,7 @@ public class KeyCrypterAESCBC implements KeyCrypter {
 
     @Override
     public Protos.Wallet.EncryptionType getUnderstoodEncryptionType() {
-        return Protos.Wallet.EncryptionType.ENCRYPTED_BLS_KEYEXCHANGE_AES;
+        return Protos.Wallet.EncryptionType.ENCRYPTED_AES;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypterAESCBC.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypterAESCBC.java
@@ -16,7 +16,10 @@
 
 package org.bitcoinj.crypto;
 
+import com.google.common.base.Preconditions;
+import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.Utils;
+import org.bitcoinj.wallet.Protos;
 import org.bouncycastle.crypto.BufferedBlockCipher;
 import org.bouncycastle.crypto.InvalidCipherTextException;
 import org.bouncycastle.crypto.engines.AESEngine;
@@ -30,18 +33,17 @@ import java.util.Arrays;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * <p>This class encrypts and decrypts byte arrays and strings using a ECDH Key Exchange as the
- * key derivation function and AES for the encryption.</p>
+ * <p>This class encrypts and decrypts byte arrays and strings using AES for the encryption.</p>
  *
  * <p>You can use this class to:</p>
  *
- * <p>1) Using a ECDSA private key and a public key, create an AES key that can encrypt and decrypt data.
+ * <p>1) Provide an ECKey or BLSSecretKey as the AES Key.
  * </p>
  *
- * <p>2) Using the AES Key generated above, you then can encrypt and decrypt any bytes using
+ * <p>2) Using the AES Key above, you then can encrypt and decrypt any bytes using
  * the AES symmetric cipher.</p>
  */
-public abstract class KeyCrypterAESCBC implements KeyCrypter {
+public class KeyCrypterAESCBC implements KeyCrypter {
 
     /**
      * Key length in bytes.
@@ -113,6 +115,31 @@ public abstract class KeyCrypterAESCBC implements KeyCrypter {
         } catch (Exception e) {
             throw new KeyCrypterException("Could not encrypt bytes.", e);
         }
+    }
+
+    @Override
+    public Protos.Wallet.EncryptionType getUnderstoodEncryptionType() {
+        return Protos.Wallet.EncryptionType.ENCRYPTED_BLS_KEYEXCHANGE_AES;
+    }
+
+    @Override
+    public KeyParameter deriveKey(CharSequence password) throws KeyCrypterException {
+        throw new UnsupportedOperationException("use one other deriveKey methods instead");
+    }
+
+    public KeyParameter deriveKey(ECKey secretKey) throws KeyCrypterException {
+        Preconditions.checkArgument(secretKey.hasPrivKey(), "secretKey must have private key bytes");
+        return new KeyParameter(secretKey.getPrivKeyBytes());
+    }
+
+    public KeyParameter deriveKey(BLSSecretKey secretKey) throws KeyCrypterException {
+        Preconditions.checkArgument(secretKey.isValid(), "secretKey must be a valid BLS private key");
+        return new KeyParameter(secretKey.getBuffer(32));
+    }
+
+    public KeyParameter deriveKey(byte [] secretKey) throws KeyCrypterException {
+        Preconditions.checkArgument(secretKey.length == 32, "secretKey must be a 32 byte byte array");
+        return new KeyParameter(secretKey);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/Protos.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Protos.java
@@ -16488,6 +16488,10 @@ public final class Protos {
        * <code>ENCRYPTED_ECDH_KEYEXCHANGE_AES = 4;</code>
        */
       ENCRYPTED_ECDH_KEYEXCHANGE_AES(4),
+      /**
+       * <code>ENCRYPTED_AES = 5;</code>
+       */
+      ENCRYPTED_AES(5),
       ;
 
       /**
@@ -16522,6 +16526,10 @@ public final class Protos {
        * <code>ENCRYPTED_ECDH_KEYEXCHANGE_AES = 4;</code>
        */
       public static final int ENCRYPTED_ECDH_KEYEXCHANGE_AES_VALUE = 4;
+      /**
+       * <code>ENCRYPTED_AES = 5;</code>
+       */
+      public static final int ENCRYPTED_AES_VALUE = 5;
 
 
       @java.lang.Override
@@ -16545,6 +16553,7 @@ public final class Protos {
           case 2: return ENCRYPTED_SCRYPT_AES;
           case 3: return ENCRYPTED_BLS_KEYEXCHANGE_AES;
           case 4: return ENCRYPTED_ECDH_KEYEXCHANGE_AES;
+          case 5: return ENCRYPTED_AES;
           default: return null;
         }
       }

--- a/core/src/main/proto/wallet.proto
+++ b/core/src/main/proto/wallet.proto
@@ -449,6 +449,7 @@ message Wallet {
     ENCRYPTED_SCRYPT_AES = 2;        // All keys are encrypted with a passphrase based KDF of scrypt and AES encryption
     ENCRYPTED_BLS_KEYEXCHANGE_AES = 3;           // Not used for wallet
     ENCRYPTED_ECDH_KEYEXCHANGE_AES = 4;          // Not used for wallet
+    ENCRYPTED_AES = 5; // Not used for wallet
   }
 
   required string network_identifier = 1; // the network used by this wallet

--- a/core/src/test/java/org/bitcoinj/crypto/KeyCrypterAESCBCTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/KeyCrypterAESCBCTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013 Jim Burton.
+ * Copyright 2014 Andreas Schildbach
+ *
+ * Licensed under the MIT license (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://opensource.org/licenses/mit-license.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.crypto;
+
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Utils;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class KeyCrypterAESCBCTest {
+
+    ECKey aliceKey;
+
+    static String secret = "my little secret is a pony that never sleeps";
+
+    @Before
+    public void setup() {
+        aliceKey = ECKey.fromPrivate(Utils.HEX.decode("7337920e97ebfe34ee82137a26ef7bd296a3132f3c6494235e1f17820770aa01"));
+    }
+
+    @Test
+    public void testEncryptionAndDecryption() {
+        //Alice is sending to Bob
+        KeyCrypterECDH aliceKeyExchangeCrypter = new KeyCrypterECDH();
+        KeyParameter aliceKeyParameter = aliceKeyExchangeCrypter.deriveKey(aliceKey);
+
+        EncryptedData encryptedData = aliceKeyExchangeCrypter.encrypt(secret.getBytes(), aliceKeyParameter);
+
+        byte [] decryptedData = aliceKeyExchangeCrypter.decrypt(encryptedData, aliceKeyParameter);
+
+        assertEquals("they should be the same string", new String(decryptedData), secret );
+    }
+}

--- a/core/src/test/java/org/bitcoinj/crypto/KeyCrypterAESCBCTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/KeyCrypterAESCBCTest.java
@@ -1,12 +1,11 @@
 /*
- * Copyright 2013 Jim Burton.
- * Copyright 2014 Andreas Schildbach
+ * Copyright 2022 Dash Core Group
  *
- * Licensed under the MIT license (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://opensource.org/licenses/mit-license.php
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
* add a test that uses a EC private key for AES

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone